### PR TITLE
openai proxy issue fix

### DIFF
--- a/code_generation/OpenAI_code_generation.ipynb
+++ b/code_generation/OpenAI_code_generation.ipynb
@@ -56,7 +56,8 @@
         "# install the latest version of kFinance package\n",
         "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
         "# install the LLM Python package\n",
-        "%pip install openai"
+        "%pip install openai\n",
+        "%pip install httpx==0.27.2"
       ]
     },
     {

--- a/function_calling/OpenAI_function_calling.ipynb
+++ b/function_calling/OpenAI_function_calling.ipynb
@@ -59,7 +59,8 @@
     "# install the latest version of kFinance package\n",
     "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
     "# install the LLM Python package\n",
-    "%pip install openai"
+    "%pip install openai\n",
+    "%pip install httpx==0.27.2"
    ]
   },
   {


### PR DESCRIPTION
The version of OpenAI installed by default on Google Colab presently is 1.54.5. In that version, there is an issue with its usage of the httpx package. This is fixed by OpenAI >= 1.55.3 (for more information, see [here](https://github.com/openai/openai-python/pull/1905)). After some experimentation, it is not simple to update the pre-installed openai package version. Therefore, until Google updates the pre-installed OpenAI Python package version, the httpx version will be set to 0.27.2 to prevent the issue