### PR TITLE
Change the pip install location for the kfinance client. 

### DIFF
--- a/basic_usage.ipynb
+++ b/basic_usage.ipynb
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz"
+    "%pip install kensho-kfinance"
    ]
   },
   {

--- a/code_generation/Anthropic_code_generation.ipynb
+++ b/code_generation/Anthropic_code_generation.ipynb
@@ -54,7 +54,7 @@
       "outputs": [],
       "source": [
         "# install the latest version of kFinance package\n",
-        "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+        "%pip install kensho-kfinance\n",
         "# install the LLM Python package\n",
         "%pip install anthropic"
       ]

--- a/code_generation/Google_Gemini_code_generation.ipynb
+++ b/code_generation/Google_Gemini_code_generation.ipynb
@@ -54,7 +54,7 @@
       "outputs": [],
       "source": [
         "# install the latest version of kFinance package\n",
-        "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+        "%pip install kensho-kfinance\n",
         "# install the LLM Python package\n",
         "%pip install google-generativeai"
       ]

--- a/code_generation/OpenAI_code_generation.ipynb
+++ b/code_generation/OpenAI_code_generation.ipynb
@@ -54,7 +54,7 @@
       "outputs": [],
       "source": [
         "# install the latest version of kFinance package\n",
-        "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+        "%pip install kensho-kfinance\n",
         "# install the LLM Python package\n",
         "%pip install openai\n",
         "%pip install httpx==0.27.2"

--- a/function_calling/Anthropic_function_calling.ipynb
+++ b/function_calling/Anthropic_function_calling.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install the LLM Python package\n",
     "%pip install anthropic"
    ]

--- a/function_calling/Google_Gemini_function_calling.ipynb
+++ b/function_calling/Google_Gemini_function_calling.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install the LLM Python package\n",
     "%pip install google-generativeai"
    ]

--- a/function_calling/OpenAI_function_calling.ipynb
+++ b/function_calling/OpenAI_function_calling.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install the LLM Python package\n",
     "%pip install openai\n",
     "%pip install httpx==0.27.2"

--- a/langchain_function_calling/langchain_function_calling_Anthropic.ipynb
+++ b/langchain_function_calling/langchain_function_calling_Anthropic.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install langchain and anthropic\n",
     "%pip install anthropic\n",
     "%pip install langchain\n",

--- a/langchain_function_calling/langchain_function_calling_Google_Gemini.ipynb
+++ b/langchain_function_calling/langchain_function_calling_Google_Gemini.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install langchain and gemini\n",
     "%pip install langchain\n",
     "%pip install google-generativeai\n",

--- a/langchain_function_calling/langchain_function_calling_OpenAI.ipynb
+++ b/langchain_function_calling/langchain_function_calling_OpenAI.ipynb
@@ -57,7 +57,7 @@
    "outputs": [],
    "source": [
     "# install the latest version of kFinance package\n",
-    "%pip install https://kfinance.kensho.com/static/kensho_finance.tar.gz\n",
+    "%pip install kensho-kfinance\n",
     "# install langchain and openai\n",
     "%pip install openai\n",
     "%pip install langchain\n",


### PR DESCRIPTION
Since it's now published, the pip command no longer needs to reference the application server.